### PR TITLE
Fix: Rename URLs of submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "backend"]
 	path = backend
-	url = https://github.com/Sakuten/lottery-backend
+	url = https://github.com/Sakuten/backend
 [submodule "frontend"]
 	path = frontend
-	url = https://github.com/Sakuten/lottery-frontend
+	url = https://github.com/Sakuten/frontend


### PR DESCRIPTION
とてもどうでもいい話ではありますが、`lottery-{backend,frontend}`は`{backend,frontend}`に名前を変えたので、それに合わせて`.gitmodules`のURLを変更しました