### PR TITLE
Fix: Specify FLASK_ENV manually in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       - FLASK_APP=app.py
       - FLASK_CONFIGURATION=development
+      - FLASK_ENV=development
     command: "/bin/bash -c 'pipenv run start:dep & pipenv run start:flask --port ${API_PORT} --host 0.0.0.0'"
     working_dir: "/code"
     volumes:


### PR DESCRIPTION
<!-- あくまでテンプレートなので必ずしもすべての項目を埋めなくてよい -->

### Step 1: 再現済み環境

 * OS: Linux coordiserver 4.16.0-2-amd64 #1 SMP Debian 4.16.16-2 (2018-06-22) x86_64 GNU/Linux
 * devenv: 3e6aa411c0b9caa08824e7aae9331c408d0d7d98
 * frontend: 2ad68b9b8b2b6dc53bd93f5f5ccb909160094eb5
 * backend: 8f35d892d2da3b30e0fc0c0fbf570f7ad62765de
  
### Step 2: 変更内容

  * Fix Sakuten/backend#53
  * FLASK_ENVをdocker-compose.yml内で指定する。

### Step 2: 検証手順

#### 再現のための手順:

  1. run `./scripts/start.sh`
  2. `docker-compose logs -f`でログを見る
  
#### 修正前の挙動:

  * `Environment: production`
  * `Debug mode: off`
とログに出ている
  
#### 修正後の挙動:

  * `Environment: development`
  * `Debug mode: on`
とログに出ている
