### PR TITLE
VS Codeの隠しフォルダをignoreする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,9 +353,6 @@ node_modules/
 # Typescript v1 declaration files
 typings/
 
-# Visual Studio setting files
-.vscode/
-
 # Visual Studio 6 build log
 *.plg
 

--- a/.gitignore
+++ b/.gitignore
@@ -353,6 +353,9 @@ node_modules/
 # Typescript v1 declaration files
 typings/
 
+# Visual Studio Code setting files
+.vscode/
+
 # Visual Studio 6 build log
 *.plg
 

--- a/.gitignore
+++ b/.gitignore
@@ -353,6 +353,9 @@ node_modules/
 # Typescript v1 declaration files
 typings/
 
+# Visual Studio setting files
+.vscode/
+
 # Visual Studio 6 build log
 *.plg
 


### PR DESCRIPTION
 * Linux LAPTOP-93OTQDA5 4.4.0-17134-Microsoft#648-Microsoft Tue Mar 05 18:57:00 PST 2019 x86_64 x86_64 x86_64 GNU/Linux
 * Sakuten/devenv@54a5652f8418586df1dc6b2ca536f3333e44ce14
 * Sakuten/frontend@b330379bf893a2363201cf4e9a64f32f0d911999
 * Sakuten/backend@fb813e9409a0b45706174cfab737f91b380e43c0

変更内容
================

  * .vscodeというVisual Studio Codeが生成する設定などのファイルが入るディレクトリのパスを、.gitignoreに追加する