### PR TITLE
node_modulesはマウントしない

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     working_dir: "/code"
     volumes:
       - "${FRONTEND_DIR}:/code"
+      - "/code/node_modules"
   backend:
     build:
       dockerfile: Dockerfile.dev


### PR DESCRIPTION

変更内容
================

  * ホストのnode_modulesディレクトリをコンテナにマウントしてしまうとOS差異があったときにnode-sassの依存性解決に失敗する、のでマウントしなくする
  * これを参照　https://budougumi0617.github.io/2018/04/04/fail-node-sass-on-docker/

修正前の挙動:
-------------

  * ホストのnode_modulesディレクトリをコンテナにマウントしてしまうとOS差異があったときにnode-sassの依存性解決に失敗する

修正後の挙動:
-------------

  *  ホストのnode_modulesディレクトリをコンテナにマウントしてしまうとOS差異があったときにnode-sassの依存性解決に失敗しない！

影響範囲
================

  * おそらくない
